### PR TITLE
Fix the URL of the SPORE RX schema

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -10,7 +10,7 @@ check: spore_validation.rx
 test: check
 
 spore_validation.rx:
-	wget http://raw.github.com/SPORE/specifications/master/spore_validation.rx
+	wget https://raw.github.com/SPORE/specifications/master/spore_validation.rx
 
 png: \
     couchdb.png \

--- a/services/Makefile
+++ b/services/Makefile
@@ -22,7 +22,7 @@ check: spore_validation.rx
 test: check
 
 spore_validation.rx:
-	wget http://raw.github.com/SPORE/specifications/master/spore_validation.rx
+	wget https://raw.github.com/SPORE/specifications/master/spore_validation.rx
 
 png: \
     amazons3.png \


### PR DESCRIPTION
GitHub is now https-only.
