### PR TITLE
Vélib'

### DIFF
--- a/apps/Makefile
+++ b/apps/Makefile
@@ -1,6 +1,6 @@
 
 VALIDATOR := perl ../utils/validator.pl --schema spore_validation.rx --description
-SPORE2DOT := perl ../utils/spore2dot.pl
+SPORE2DOT := perl -CO ../utils/spore2dot.pl
 
 check: spore_validation.rx
 	@make -C couchdb check
@@ -18,7 +18,7 @@ png: \
 	@make -C couchdb png
 
 %.png : %.dot
-	dot -T png -o $@ $<
+	dot -T png -Gutf8 -o $@ $<
 
 %.dot: %.json
 	$(SPORE2DOT) $< > $@

--- a/services/Makefile
+++ b/services/Makefile
@@ -18,6 +18,7 @@ check: spore_validation.rx
 	@$(VALIDATOR) ohloh.json
 	@$(VALIDATOR) twitter.json
 	@$(VALIDATOR) intervals.json
+	@$(VALIDATOR) velib.json
 
 test: check
 
@@ -38,6 +39,7 @@ png: \
     ohloh.png \
     intervals.png \
     indextank.png \
+    velib.png \
     twitter.png
 	@make -C github png
 	@make -C googlemaps png

--- a/services/Makefile
+++ b/services/Makefile
@@ -1,5 +1,5 @@
 VALIDATOR := perl ../utils/validator.pl --schema spore_validation.rx --description
-SPORE2DOT := perl ../utils/spore2dot.pl
+SPORE2DOT := perl -CO ../utils/spore2dot.pl
 
 check: spore_validation.rx
 	@make -C github check
@@ -44,7 +44,7 @@ png: \
 	@make -C linkedin png
 
 %.png : %.dot
-	dot -T png -o $@ $<
+	dot -T png -Gutf8 -o $@ $<
 
 %.dot: %.json
 	$(SPORE2DOT) $< > $@

--- a/services/velib.json
+++ b/services/velib.json
@@ -1,0 +1,22 @@
+{
+    "name": "Vélib'",
+    "authority": "GITHUB:dolmen",
+    "base_url": "http://www.velib.paris.fr/",
+    "version": "1.0",
+    "methods": {
+	"list": {
+	    "path": "/service/carto",
+	    "method": "GET",
+	    "expected_status": [200]
+	},
+	"details": {
+	    "path": "/service/stationdetails/:station",
+	    "method": "GET",
+	    "required_params": [
+		"station"
+	    ],
+	    "expected_status": [200]
+	}
+    },
+    "formats": [ "xml" ]
+}


### PR DESCRIPTION
Add the SPORE spec for the Vélib' service.
Also fixes Makefile to correctly handle UTF-8 in SPORE specs when generating PNG output.
